### PR TITLE
Use proper order for name generation and handle commas

### DIFF
--- a/lua/completion_vcard.lua
+++ b/lua/completion_vcard.lua
@@ -20,8 +20,16 @@ local function get_contacts(vcard_directory)
             if vim.startswith(line, 'FN:') then
                 name = line:sub(4)
             elseif vim.startswith(line, 'N:') and name == nil then
-                local parts = vim.fn.split(line:sub(3), ';')
-                name = vim.trim(table.concat(parts, ' '))
+                local components = vim.fn.split(line:sub(3), ';')
+                if #components > 1 then
+                    components = {components[2], components[1]}
+                end
+                local joined_components = {}
+                for _, component in ipairs(components) do
+                    local joined_component = component:gsub('([^\\]),', '%1 '):gsub('([^\\])\\,', '%1,')
+                    table.insert(joined_components, joined_component)
+                end
+                name = vim.trim(table.concat(joined_components, ' '))
             elseif line:match('EMAIL') then
                 table.insert(emails, line:match(':(.*)'))
             end


### PR DESCRIPTION
Thanks for fixing the janky code in my last PR in f32d868, as you can probably tell I'm new to lua! There's one thing about the changes though that doesn't handle things exactly as intended though. Sorry, I should've explained this better in my earlier PR, but there's a specific order to the components in the `N` identification property, according to [the spec here](https://datatracker.ietf.org/doc/html/rfc6350#section-6.2.2), the order of the components is: "Family Names..., Given Names, Additional Names, Honorific Prefixes, and Honorific Suffixes."

Given that this completion source is for emails, I believe we only want to use the given and family names, right? So this PR ensures that if there are more than 1 components in the `N` tag, we only use the first two, in reverse order, so that we end up with "{Given Name} {Family Name} <{email}>". Also, while I was looking at the spec I noticed in the examples that commas should be replaced with spaces unless escaped, so I fixed that too. Again, feel free to clean things up if there's a neater way, like I mentioned, I'm new to lua.